### PR TITLE
fix warnings gererated by clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,4 @@
+CC = gcc
 ifndef SAMPLE_PERIOD_MS
 SAMPLE_PERIOD_MS = 10
 endif

--- a/src/netem.c
+++ b/src/netem.c
@@ -63,7 +63,7 @@ char **netem_list_ifaces()
 		char *j = rtnl_link_get_name(link);
 		if (strcmp("lo", j) != 0) {
 			*i = malloc(strlen(j) + 1);
-			sprintf(*i, j);
+			sprintf(*i, "%s", j);
 			i++;
 			//  rtnl_link_put(link); // FIXME: Yes? No?
 		}


### PR DESCRIPTION
I went looking into static analyzers and found that clang includes one, (I note the license disagreement) so I ran JT through clang and got two warnings. One, after research is wrong, the other is patched here. This is a pedantic one so feel free to drop it. Please do school me on gcc/clang if you have an opinion. Added the makefile variable to do the clang build, reverted it to gcc for the final commit.