### PR TITLE
Cleanup server-side debugging - using syslog

### DIFF
--- a/deps/toptalk/intervals.c
+++ b/deps/toptalk/intervals.c
@@ -9,7 +9,6 @@
 #include <pthread.h>
 #include <poll.h>
 #include <errno.h>
-#include <syslog.h>
 
 #include "utlist.h"
 #include "uthash.h"
@@ -381,7 +380,7 @@ static int free_pcap(struct pcap_info *pi)
 
 static void set_affinity(struct tt_thread_info *ti)
 {
-	int s, j;
+	int s;
 	cpu_set_t cpuset;
 	pthread_t thread;
 	thread = pthread_self();
@@ -403,14 +402,18 @@ static void set_affinity(struct tt_thread_info *ti)
 		handle_error_en(s, "pthread_getaffinity_np");
 	}
 
-	char buff[64];
-	for (j = 0; j < CPU_SETSIZE; j++) {
-		if (CPU_ISSET(j, &cpuset)) {
-			snprintf(buff, sizeof(buff), " CPU%d", j);
-		}
-	}
-	syslog(LOG_DEBUG, "[RT thread %s] priority [%d] CPU affinity: %s",
-		ti->thread_name, ti->thread_prio, buff);
+    /*
+	int j;
+	printf("RT thread [%s] priority [%d] CPU affinity: ",
+ 	       ti->thread_name,
+ 	       ti->thread_prio);
+  	for (j = 0; j < CPU_SETSIZE; j++) {
+  		if (CPU_ISSET(j, &cpuset)) {
+ 			printf(" CPU%d", j);
+  		}
+  	}
+ 	printf("\n"); 
+	*/
 }
 
 static int init_realtime(struct tt_thread_info *ti)
@@ -460,7 +463,7 @@ void *tt_intervals_run(void *p)
 		} else {
 			/* poll timeout */
 			if (fds[0].revents) {
-				syslog(LOG_INFO, "error. revents: %x\n",
+					fprintf(stderr, "error. revents: %x\n",
 				        fds[0].revents);
 			}
 		}

--- a/deps/toptalk/intervals.c
+++ b/deps/toptalk/intervals.c
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #include <poll.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include "utlist.h"
 #include "uthash.h"
@@ -402,15 +403,14 @@ static void set_affinity(struct tt_thread_info *ti)
 		handle_error_en(s, "pthread_getaffinity_np");
 	}
 
-	printf("RT thread [%s] priority [%d] CPU affinity: ",
-	       ti->thread_name,
-	       ti->thread_prio);
+	char buff[64];
 	for (j = 0; j < CPU_SETSIZE; j++) {
 		if (CPU_ISSET(j, &cpuset)) {
-			printf(" CPU%d", j);
+			snprintf(buff, sizeof(buff), " CPU%d", j);
 		}
 	}
-	printf("\n");
+	syslog(LOG_DEBUG, "[RT thread %s] priority [%d] CPU affinity: %s",
+		ti->thread_name, ti->thread_prio, buff);
 }
 
 static int init_realtime(struct tt_thread_info *ti)
@@ -460,7 +460,7 @@ void *tt_intervals_run(void *p)
 		} else {
 			/* poll timeout */
 			if (fds[0].revents) {
-				fprintf(stderr, "error. revents: %x\n",
+				syslog(LOG_INFO, "error. revents: %x\n",
 				        fds[0].revents);
 			}
 		}

--- a/messages/src/jt_msg_list_ifaces.c
+++ b/messages/src/jt_msg_list_ifaces.c
@@ -26,10 +26,15 @@ int jt_iface_list_printer(void *data)
 	int i;
 	struct jt_iface_list *il = (struct jt_iface_list *)data;
 
-	char buff[128];
+	char buff[128] = {0};
+	char *offset = buff;
+	int blen = sizeof(buff);
 	for (i = 0; i < il->count; i++) {
-		snprintf(buff, sizeof(buff), "\t%s\n", il->ifaces[i]);
+		snprintf(offset, blen, "%s ", il->ifaces[i]);
+		blen -= strlen(offset);
+		offset += strlen(offset);
 	}
+
 	syslog(LOG_INFO, "Iface list: %s", buff);
 	return 0;
 }

--- a/messages/src/jt_msg_list_ifaces.c
+++ b/messages/src/jt_msg_list_ifaces.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <assert.h>
 #include <jansson.h>
+#include <syslog.h>
 
 #include "jt_message_types.h"
 #include "jt_messages.h"
@@ -25,10 +26,11 @@ int jt_iface_list_printer(void *data)
 	int i;
 	struct jt_iface_list *il = (struct jt_iface_list *)data;
 
-	printf("Iface list:\n");
+	char buff[128];
 	for (i = 0; i < il->count; i++) {
-		printf("\t%s\n", il->ifaces[i]);
+		snprintf(buff, sizeof(buff), "\t%s\n", il->ifaces[i]);
 	}
+	syslog(LOG_INFO, "Iface list: %s", buff);
 	return 0;
 }
 

--- a/messages/src/jt_msg_netem_params.c
+++ b/messages/src/jt_msg_netem_params.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <assert.h>
 #include <jansson.h>
+#include <syslog.h>
 
 #include "jt_message_types.h"
 #include "jt_messages.h"
@@ -27,11 +28,11 @@ int jt_netem_params_printer(void *data)
 {
 	struct jt_msg_netem_params *p = data;
 
-	printf("Impairment params:\n"
-	       "\tInterface:  %s\n"
-	       "\tDelay:      %dms\n"
-	       "\tJitter:  +/-%dms\n"
-	       "\tLoss:       %d\n",
+	syslog(LOG_INFO, "Impairment params: "
+	       "\tInterface:  %s"
+	       "\tDelay:      %dms"
+	       "\tJitter:  +/-%dms"
+	       "\tLoss:       %d",
 	       p->iface, p->delay, p->jitter, p->loss);
 	return 0;
 }

--- a/messages/src/jt_msg_sample_period.c
+++ b/messages/src/jt_msg_sample_period.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <assert.h>
 #include <jansson.h>
+#include <syslog.h>
 
 #include "jt_message_types.h"
 #include "jt_messages.h"
@@ -21,7 +22,7 @@ int jt_sample_period_free(void *data)
 int jt_sample_period_printer(void *data)
 {
 	int *sp = data;
-	printf("Sampling period: %d\n", *sp);
+	syslog(LOG_INFO, "Sampling period: %d\n", *sp);
 	return 0;
 }
 

--- a/messages/src/jt_msg_select_iface.c
+++ b/messages/src/jt_msg_select_iface.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <assert.h>
 #include <jansson.h>
+#include <syslog.h>
 
 #include "jt_message_types.h"
 #include "jt_messages.h"
@@ -24,7 +25,7 @@ int jt_select_iface_free(void *data)
 int jt_select_iface_printer(void *data)
 {
 	char(*iface)[MAX_IFACE_LEN] = data;
-	printf("Selected Iface %s\n", *iface);
+	syslog(LOG_INFO, "Selected Iface %s\n", *iface);
 	return 0;
 }
 

--- a/messages/src/jt_msg_set_netem.c
+++ b/messages/src/jt_msg_set_netem.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <assert.h>
 #include <jansson.h>
+#include <syslog.h>
 
 #include "jt_message_types.h"
 #include "jt_messages.h"
@@ -24,7 +25,7 @@ int jt_set_netem_printer(void *data)
 {
 	struct jt_msg_netem_params *p = data;
 
-	printf("Impairment params:\n"
+	syslog(LOG_INFO, "Impairment params:\n"
 	       "\tInterface:  %s\n"
 	       "\tDelay:      %dms\n"
 	       "\tJitter:  +/-%dms\n"

--- a/messages/src/jt_msg_stats.c
+++ b/messages/src/jt_msg_stats.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <jansson.h>
 #include <inttypes.h>
+#include <syslog.h>
 
 #include "jt_message_types.h"
 #include "jt_messages.h"
@@ -36,7 +37,7 @@ int jt_stats_printer(void *data)
 {
 	struct jt_msg_stats *stats = (struct jt_msg_stats *)data;
 
-	printf("\rT: %"PRId64".%09"PRId64", Rx: %10"PRId64" Tx: %10"PRId64" PtkRx: %10"PRId32" PktTx: %10"PRId32" E: %10"PRId32,
+	syslog(LOG_INFO, "\rT: %"PRId64".%09"PRId64", Rx: %10"PRId64" Tx: %10"PRId64" PtkRx: %10"PRId32" PktTx: %10"PRId32" E: %10"PRId32,
 	       stats->timestamp.tv_sec,
 	       stats->timestamp.tv_nsec,
 	       stats->mean_rx_bytes,

--- a/messages/src/jt_msg_toptalk.c
+++ b/messages/src/jt_msg_toptalk.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <jansson.h>
 #include <inttypes.h>
+#include <syslog.h>
 
 #include "jt_message_types.h"
 #include "jt_messages.h"
@@ -32,7 +33,7 @@ int jt_toptalk_printer(void *data)
 {
 	struct jt_msg_toptalk *t = (struct jt_msg_toptalk*)data;
 
-	printf("\r t:%ld.%09ld fc:%"PRId32", b: %"PRId64", p:%"PRId64"\n",
+	syslog(LOG_INFO, "\r t:%ld.%09ld fc:%"PRId32", b: %"PRId64", p:%"PRId64"\n",
 	       t->timestamp.tv_sec, t->timestamp.tv_nsec, t->tflows, t->tbytes,
 	       t->tpackets);
 	return 0;

--- a/server/compute_thread.c
+++ b/server/compute_thread.c
@@ -362,10 +362,14 @@ static void set_affinity()
 		handle_error_en(s, "pthread_getaffinity_np");
 	}
 
-	char buff[64];
+	char buff[64] = {0};
+	char *offset = buff;
+	int blen = sizeof(buff);
 	for (j = 0; j < CPU_SETSIZE; j++) {
 		if (CPU_ISSET(j, &cpuset)) {
-			snprintf(buff, sizeof(buff), " CPU%d", j);
+			snprintf(offset, blen, "CPU%d ", j);
+			blen -= strlen(offset);
+			offset += strlen(offset);
 		}
 	}
 

--- a/server/jt_server_message_handler.c
+++ b/server/jt_server_message_handler.c
@@ -203,13 +203,16 @@ int jt_srv_send_iface_list()
 		free(il);
 		return -1;
 	} else {
-		char buff[64];
+		char buff[128] = {0};
+		char *offset = buff;
 		do {
-			snprintf(buff, sizeof(buff), " %s", *iface);
+			snprintf(offset, sizeof(buff) - (offset - buff), " %s",
+			         *iface);
+			offset = offset + strlen(*iface) + 1;
 			(il->count)++;
 			iface++;
 		} while (*iface);
-		
+
 		syslog(LOG_INFO, "available ifaces: %s", buff);
 	}
 

--- a/server/jt_server_message_handler.c
+++ b/server/jt_server_message_handler.c
@@ -205,10 +205,12 @@ int jt_srv_send_iface_list()
 	} else {
 		char buff[128] = {0};
 		char *offset = buff;
+		int blen = sizeof(buff);
 		do {
-			snprintf(offset, sizeof(buff) - (offset - buff), " %s",
-			         *iface);
-			offset = offset + strlen(*iface) + 1;
+			snprintf(offset, blen, "%s ", *iface);
+			blen -= strlen(offset);
+			offset += strlen(offset);
+
 			(il->count)++;
 			iface++;
 		} while (*iface);

--- a/server/mq_generic.c
+++ b/server/mq_generic.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <syslog.h>
 #include <pthread.h>
 
 #include "mq_generic.h"
@@ -39,7 +40,7 @@ int NS(init)()
 	pthread_mutex_lock(&mq_mutex);
 	assert(!queue);
 	if (0 == consumer_count) {
-		printf("creating new queue for %d messages of %lu bytes each\n",
+		syslog(LOG_INFO, "creating new queue for %d messages of %lu bytes each\n",
 		       MAX_Q_DEPTH - 1, sizeof(struct NS(msg)));
 
 		queue = malloc(BUF_BYTE_LEN);
@@ -97,7 +98,7 @@ int NS(consumer_subscribe)(unsigned long *subscriber_id)
 
 	pthread_mutex_unlock(&mq_mutex);
 
-	printf("consumer %lu joined\n", *subscriber_id);
+	syslog(LOG_INFO, "consumer %lu joined\n", *subscriber_id);
 
 	return 0;
 }
@@ -119,7 +120,7 @@ int NS(consumer_unsubscribe)(unsigned long subscriber_id)
 
 	pthread_mutex_unlock(&mq_mutex);
 
-	printf("consumer %lu left\n", subscriber_id);
+	syslog(LOG_INFO, "consumer %lu left\n", subscriber_id);
 
 	return 0;
 }

--- a/server/proto.c
+++ b/server/proto.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <syslog.h>
 
 #include <libwebsockets.h>
 
@@ -28,7 +29,7 @@ void dump_handshake_info(struct lws *wsi)
 
 		lws_hdr_copy(wsi, buf, sizeof buf, n);
 
-		fprintf(stderr, "    %s = %s\n", (char *)c, buf);
+		syslog(LOG_INFO, "    %s = %s", (char *)c, buf);
 		n++;
 	} while (c);
 }

--- a/server/sampling_thread.c
+++ b/server/sampling_thread.c
@@ -209,12 +209,17 @@ static void set_affinity()
 		handle_error_en(s, "pthread_getaffinity_np");
 	}
 
-	char buff[64];
+	char buff[64] = {0};
+	char *offset = buff;
+	int blen = sizeof(buff);
 	for (j = 0; j < CPU_SETSIZE; j++) {
 		if (CPU_ISSET(j, &cpuset)) {
-			snprintf(buff, sizeof(buff), " CPU%d", j);
+			snprintf(offset, blen, "CPU%d ", j);
+			blen -= strlen(offset);
+			offset += strlen(offset);
 		}
 	}
+
 	syslog(LOG_DEBUG, "[RT thread %s] priority [%d] CPU affinity: %s",
 		thread_info.thread_name, thread_info.thread_prio, buff);
 }

--- a/server/sampling_thread.c
+++ b/server/sampling_thread.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <assert.h>
+#include <syslog.h>
 
 #include <linux/types.h>
 #include <netlink/netlink.h>
@@ -208,14 +209,14 @@ static void set_affinity()
 		handle_error_en(s, "pthread_getaffinity_np");
 	}
 
-	printf("RT thread [%s] priority [%d] CPU affinity: ",
-	       thread_info.thread_name, thread_info.thread_prio);
+	char buff[64];
 	for (j = 0; j < CPU_SETSIZE; j++) {
 		if (CPU_ISSET(j, &cpuset)) {
-			printf(" CPU%d", j);
+			snprintf(buff, sizeof(buff), " CPU%d", j);
 		}
 	}
-	printf("\n");
+	syslog(LOG_DEBUG, "[RT thread %s] priority [%d] CPU affinity: %s",
+		thread_info.thread_name, thread_info.thread_prio, buff);
 }
 
 static int init_realtime(void)

--- a/server/server-main.c
+++ b/server/server-main.c
@@ -62,7 +62,7 @@ void sighandler(int sig __attribute__((unused)))
 
 static struct option options[] = {
 	{ "help", no_argument, NULL, 'h' },
-	{ "debug", required_argument, NULL, 'd' },
+	{ "debug", required_argument, NULL, '1' },
 	{ "port", required_argument, NULL, 'p' },
 	{ "ssl", no_argument, NULL, 's' },
 	{ "interface", required_argument, NULL, 'i' },
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
 	int opts = 0;
 	char interface_name[128] = "";
 	const char *iface = NULL;
-	int syslog_options = LOG_PID | LOG_PERROR;
+	int syslog_options = LOG_PID;
 	struct lws_context_creation_info info;
 
 	int debug_level = 7;
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
 	info.port = WEB_SERVER_PORT;
 
 	while (n >= 0) {
-		n = getopt_long(argc, argv, "eci:hsap:d:Dr:", options, NULL);
+		n = getopt_long(argc, argv, "eci:hsap:dDr:", options, NULL);
 		if (n < 0)
 			continue;
 		switch (n) {
@@ -119,8 +119,13 @@ int main(int argc, char **argv)
 			syslog_options &= ~LOG_PERROR;
 			break;
 #endif
-		case 'd':
+		// opt that wont be a short opt either - for long --debug
+		case '1':
 			debug_level = atoi(optarg);
+			// print if changing debugging level
+			// no break
+		case 'd':
+			syslog_options |= LOG_PERROR;
 			break;
 		case 's':
 			use_ssl = 1;
@@ -140,8 +145,6 @@ int main(int argc, char **argv)
 			break;
 		case 'r':
 			resource_path = optarg;
-			printf("Setting resource path to \"%s\"\n",
-			       resource_path);
 			break;
 		case 'h':
 			fprintf(stderr,
@@ -168,14 +171,14 @@ int main(int argc, char **argv)
 
 	/* we will only try to log things according to our debug_level */
 	setlogmask(LOG_UPTO(LOG_DEBUG));
-	openlog("lwsts", syslog_options, LOG_DAEMON);
+	openlog("jt-server", syslog_options, LOG_DAEMON);
 
 	/* tell the library what debug level to emit and to send it to syslog */
 	lws_set_log_level(debug_level, lwsl_emit_syslog);
 
 	lwsl_notice("jittertrap server\n");
 
-	printf("Using resource path \"%s\"\n", resource_path);
+	lwsl_notice("Using resource path \"%s\"\n", resource_path);
 
 	info.iface = iface;
 	info.protocols = protocols;

--- a/server/server-main.c
+++ b/server/server-main.c
@@ -119,11 +119,11 @@ int main(int argc, char **argv)
 			syslog_options &= ~LOG_PERROR;
 			break;
 #endif
-		// opt that wont be a short opt either - for long --debug
+		/* opt that wont be a short opt either - for long --debug */
 		case '1':
 			debug_level = atoi(optarg);
-			// print if changing debugging level
-			// no break
+			/* print if changing debugging level */
+			/* no break */
 		case 'd':
 			syslog_options |= LOG_PERROR;
 			break;

--- a/server/tt_thread.c
+++ b/server/tt_thread.c
@@ -162,10 +162,14 @@ static void set_affinity()
 		handle_error_en(s, "pthread_getaffinity_np");
 	}
 
-	char buff[64];
+	char buff[64] = {0};
+	char *offset = buff;
+	int blen = sizeof(buff);
 	for (j = 0; j < CPU_SETSIZE; j++) {
 		if (CPU_ISSET(j, &cpuset)) {
-			snprintf(buff, sizeof(buff), " CPU%d", j);
+			snprintf(offset, blen, "CPU%d ", j);
+			blen -= strlen(offset);
+			offset += strlen(offset);
 		}
 	}
 

--- a/server/tt_thread.c
+++ b/server/tt_thread.c
@@ -3,6 +3,7 @@
 #include <sched.h>
 #include <errno.h>
 #include <pthread.h>
+#include <syslog.h>
 
 #include <jansson.h>
 
@@ -161,15 +162,15 @@ static void set_affinity()
 		handle_error_en(s, "pthread_getaffinity_np");
 	}
 
-	printf("RT thread [%s] priority [%d] CPU affinity: ",
-	       iti.thread_name, iti.thread_prio);
-
+	char buff[64];
 	for (j = 0; j < CPU_SETSIZE; j++) {
 		if (CPU_ISSET(j, &cpuset)) {
-			printf(" CPU%d", j);
+			snprintf(buff, sizeof(buff), " CPU%d", j);
 		}
 	}
-	printf("\n");
+
+	syslog(LOG_DEBUG, "[RT thread %s] priority [%d] CPU affinity: %s",
+		iti.thread_name, iti.thread_prio, buff);
 }
 
 static int init_realtime(void)


### PR DESCRIPTION
Update logging to be quiet by default - addresses issue #38 

To turn on either with just -d:
`    sudo server/jt-server --resource_path html5-client/output/ -d
`
or with changing the debug level (or both args):
`    sudo server/jt-server --resource_path html5-client/output/ --debug 7
`

Just reused the syslog interface that was being created for libwebsockets as it's thread safe and output to terminal can easily be switched off (adding or removing LOG_PERROR). Did rename the syslog process name to be consistent as well. 

Example: 
```
jt-server[43871]: jittertrap server
jt-server[43871]: Using resource path "html5-client/output/"
jt-server[43871]: Initial logging level 7
jt-server[43871]: Libwebsockets version: 1.7.1 unknown-build-hash
jt-server[43871]: IPV6 not compiled in
jt-server[43871]: libev support compiled in but disabled
jt-server[43871]:  Threads: 1 each 1024 fds
jt-server[43871]:  mem: platform fd map:  8192 bytes
jt-server[43871]:  mem: per-conn:          808 bytes + protocol rx buf
jt-server[43871]:  canonical_hostname = 
jt-server[43871]:  Compiled with OpenSSL support
jt-server[43871]:  Using non-SSL mode
jt-server[43871]:  Listening on port 80
jt-server[43871]: creating new queue for 15 messages of 4096 bytes each
jt-server[43871]: switching to iface: [ens33]
jt-server[43871]: [RT thread jt-toptalk] priority [3] CPU affinity:  CPU0
jt-server[43871]: creating new queue for 15 messages of 2288 bytes each
jt-server[43871]: creating new queue for 15 messages of 160 bytes each
jt-server[43871]: [RT thread jt-intervals] priority [2] CPU affinity:  CPU0
jt-server[43871]: [RT thread jt-compute] priority [1] CPU affinity:  CPU0
jt-server[43871]: consumer 42424242 joined
jt-server[43871]: consumer 42424242 joined
jt-server[43871]: available ifaces:  ens33
jt-server[43871]: [RT thread jt-sample] priority [2] CPU affinity:  CPU0
```

Shouldn't be any additional whitespace this time either ;)