### PR TITLE
Don't use libwebsockets extensions if unavailable

### DIFF
--- a/cli-client/main.c
+++ b/cli-client/main.c
@@ -31,6 +31,7 @@ static struct option options[] = { { "help", no_argument, NULL, 'h' },
 	                           { NULL, 0, 0, 0 } };
 
 static const struct lws_extension exts[] = {
+#ifndef LWS_WITHOUT_EXTENSIONS
         {
 		"permessage-deflate",
 		lws_extension_callback_pm_deflate,
@@ -41,6 +42,7 @@ static const struct lws_extension exts[] = {
 		lws_extension_callback_pm_deflate,
 		"deflate_frame"
 	},
+#endif
 	{ NULL, NULL, NULL /* terminator */ }
 };
 

--- a/server/server-main.c
+++ b/server/server-main.c
@@ -70,6 +70,7 @@ static struct option options[] = {
 };
 
 static const struct lws_extension exts[] = {
+#ifndef LWS_WITHOUT_EXTENSIONS
 	{
 		"permessage-deflate",
 		lws_extension_callback_pm_deflate,
@@ -80,6 +81,7 @@ static const struct lws_extension exts[] = {
 		lws_extension_callback_pm_deflate,
 		"deflate_frame"
 	},
+#endif
 	{ NULL, NULL, NULL /* terminator */ }
 };
 


### PR DESCRIPTION
The default in recent versions of libwebsockets is to build with the
`LWS_WITHOUT_EXTENSIONS` enabled, resulting in a build without the
`permessage-deflate` extension.

So don't use that extension if it is unavailable.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>

Can anyone with more insight in the code check if this is a valid solution. Fixes the build and seems to be working for me on Fedora 34.