### PR TITLE
Potential fix for code scanning alert no. 15: Unvalidated dynamic method call

### DIFF
--- a/html5-client/src/js/jittertrap-websocket.js
+++ b/html5-client/src/js/jittertrap-websocket.js
@@ -145,7 +145,7 @@
       }
 
       const handler = messageHandlers[msg.msg];
-      if (handler) {
+      if (Object.prototype.hasOwnProperty.call(messageHandlers, msg.msg) && typeof handler === 'function') {
         handler(msg.p);
       } else {
         console.log("unhandled message: " + evt.data);


### PR DESCRIPTION
Potential fix for [https://github.com/acooks/jittertrap/security/code-scanning/15](https://github.com/acooks/jittertrap/security/code-scanning/15)

To fix the problem, we should ensure that the handler is only called if:
1. The property exists directly on the `messageHandlers` object (not inherited from the prototype chain).
2. The property value is a function.

This can be done by replacing the current check (`if (handler) { handler(msg.p); }`) with a check using `Object.prototype.hasOwnProperty.call(messageHandlers, msg.msg)` and `typeof handler === 'function'`. Only if both conditions are true should the handler be called. This change should be made in the `sock.onmessage` function, specifically lines 147–149.

No new imports are needed, as `Object.prototype.hasOwnProperty` is available globally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
