### PR TITLE
feat(layout): improve responsive chart layout

### DIFF
--- a/html5-client/src/css/jittertrap.css
+++ b/html5-client/src/css/jittertrap.css
@@ -120,3 +120,21 @@
 footer a {
   color: #4682B4;
 }
+
+@media (min-width: 1920px) {
+  #chartsPanel .tab-content {
+    display: flex;
+    flex-direction: row;
+  }
+
+  #tputPanel, #toptalkPanel {
+    display: block !important;
+    opacity: 1 !important;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+
+  #showTputPanel, #showTopTalkPanel {
+    display: none;
+  }
+}

--- a/html5-client/src/html/index.tpl.html
+++ b/html5-client/src/html/index.tpl.html
@@ -21,7 +21,7 @@
 
   </head>
   <body>
-    <div class="container pt-3">
+    <div class="container-fluid pt-3">
       <div class="card">
         <div class="card-body">
         <div class="row align-items-center">
@@ -69,7 +69,7 @@
       <!-- end modals -->
     </div>
 
-    <footer class="container pt-3 text-center">
+    <footer class="container-fluid pt-3 text-center">
       <p>
         <a href="#" data-toggle="modal" data-target="#about">About</a>
         &middot;

--- a/html5-client/src/js/jittertrap-chart-toptalk.js
+++ b/html5-client/src/js/jittertrap-chart-toptalk.js
@@ -294,6 +294,11 @@
       const width = size.width - margin.left - margin.right;
       const height = 300; // Use a fixed height for the chart drawing area
 
+      // Update canvas and SVG dimensions
+      canvas.attr("width", width)
+            .attr("height", height);
+      svg.attr("width", width + margin.left + margin.right);
+
       xScale = d3.scaleLinear().range([0, width]);
       /* compute the domain of x as the [min,max] extent of timestamps
        * of the first (largest) flow */
@@ -314,8 +319,8 @@
       xAxis.scale(xScale);
       yAxis.scale(yScale);
 
-      xGrid.scale(xScale);
-      yGrid.scale(yScale);
+      xGrid.scale(xScale).tickSize(-height);
+      yGrid.scale(yScale).tickSize(-width);
 
       svg = d3.select("#chartToptalk");
 


### PR DESCRIPTION
This commit introduces a more responsive layout for the charts.

- The main container is now fluid, allowing the charts to use the full width of the screen.
- On screens wider than 1920px, the Throughput and Top Talkers charts are displayed side-by-side.
- A bug was fixed where the Top Talkers chart and its grid were not resizing correctly when the window size changed.