### PR TITLE
Make third-party JS paths configurable

### DIFF
--- a/html5-client/Makefile
+++ b/html5-client/Makefile
@@ -103,6 +103,12 @@ assemble-html: createdirs
 	perl -pe 's|##PCAP-BUTTON##|`cat $(PCAP_BUTTON_PART)`|ge' -i ${TPL}
 	perl -pe 's|##PCAP-DISABLED-MODAL##|`cat $(PCAP_DISABLED_MODAL_PART)`|ge' -i ${TPL}
 	perl -pe 's|##PRODUCT-BRANDING##|${PRODUCT_BRANDING}|ge' -i ${TPL}
+	perl -pe 's|##JQUERY-JS##|${JQUERY_JS}|g' -i ${TPL}
+	perl -pe 's|##MUSTACHE-JS##|${MUSTACHE_JS}|g' -i ${TPL}
+	perl -pe 's|##CBUFFER-JS##|${CBUFFER_JS}|g' -i ${TPL}
+	perl -pe 's|##BOOTSTRAP-BUNDLE-JS##|${BOOTSTRAP_BUNDLE_JS}|g' -i ${TPL}
+	perl -pe 's|##D3-JS##|${D3_JS}|g' -i ${TPL}
+	perl -pe 's|##PAKO-JS##|${PAKO_JS}|g' -i ${TPL}
 
 install:
 	install -d ${DESTDIR}/var/lib/jittertrap/

--- a/html5-client/src/html/index.tpl.html
+++ b/html5-client/src/html/index.tpl.html
@@ -12,12 +12,12 @@
 
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
 
-    <script type="text/javascript" src="js/jquery-3.7.1.min.js"></script>
-    <script type="text/javascript" src="js/mustache.min.js"></script>
-    <script type="text/javascript" src="js/cbuffer.js"></script>
-    <script type="text/javascript" src="js/bootstrap.bundle.min.js"></script>
-    <script type="text/javascript" src="js/d3.v7.min.js"></script>
-    <script type="text/javascript" src="js/pako.min.js"></script>
+    <script type="text/javascript" src="##JQUERY-JS##"></script>
+    <script type="text/javascript" src="##MUSTACHE-JS##"></script>
+    <script type="text/javascript" src="##CBUFFER-JS##"></script>
+    <script type="text/javascript" src="##BOOTSTRAP-BUNDLE-JS##"></script>
+    <script type="text/javascript" src="##D3-JS##"></script>
+    <script type="text/javascript" src="##PAKO-JS##"></script>
     <script type="text/javascript" src="js/jittertrap-concat.js"></script>
 
   </head>

--- a/make.config
+++ b/make.config
@@ -56,6 +56,36 @@ WEB_SERVER_DOCUMENT_ROOT = /var/lib/jittertrap
 endif
 
 # ------------------------------------------------------------------------------
+# HTML Client Asset Locations
+# ------------------------------------------------------------------------------
+
+# Override these at build time when distribution packages serve JavaScript
+# libraries from system-wide paths instead of JitterTrap's bundled web assets.
+ifndef JQUERY_JS
+JQUERY_JS = js/jquery-3.7.1.min.js
+endif
+
+ifndef MUSTACHE_JS
+MUSTACHE_JS = js/mustache.min.js
+endif
+
+ifndef CBUFFER_JS
+CBUFFER_JS = js/cbuffer.js
+endif
+
+ifndef BOOTSTRAP_BUNDLE_JS
+BOOTSTRAP_BUNDLE_JS = js/bootstrap.bundle.min.js
+endif
+
+ifndef D3_JS
+D3_JS = js/d3.v7.min.js
+endif
+
+ifndef PAKO_JS
+PAKO_JS = js/pako.min.js
+endif
+
+# ------------------------------------------------------------------------------
 # Performance Tuning
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #42.

This makes the third-party JavaScript asset URLs in the generated HTML configurable at build time while preserving the current bundled defaults.

Changes:
- adds build configuration variables for jquery, mustache, cbuffer, bootstrap bundle, d3, and pako
- replaces hard-coded third-party script paths in `index.tpl.html` with template placeholders
- substitutes those placeholders during `assemble-html`

Verification:
- manually assembled `html5-client/output/index.html` with the default bundled paths and confirmed all placeholders were replaced
- manually assembled a custom-path variant using `/usr/share/javascript/...` style paths
- `git diff --check`