### PR TITLE
feat: add rate-limit support to netem impairments (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ JitterTrap is a real-time network performance analysis tool for engineers workin
 - In-browser video playback via WebRTC (click the play button on any detected stream)
 
 **Network Impairment Emulation**
-- Inject delay, jitter, and packet loss on egress traffic
+- Inject delay, jitter, packet loss, and rate limit on egress traffic
 - Scriptable impairment programs for automated testing
 
 **Packet Capture**
@@ -35,7 +35,7 @@ JitterTrap is a real-time network performance analysis tool for engineers workin
 ### Use Cases
 
 - **Characterise source behaviour** — measure throughput, packet rates, and jitter from devices under test
-- **Characterise destination behaviour** — inject impairments to verify application resilience to delay/loss
+- **Characterise destination behaviour** — inject impairments to verify application resilience to delay, jitter, loss, and rate limiting
 - **Debug TCP performance** — identify RTT spikes, window limitations, and retransmission patterns
 - **Network congestion analysis** — real-time visibility into traffic patterns
 

--- a/html5-client/src/html/panel-impairments.part.html
+++ b/html5-client/src/html/panel-impairments.part.html
@@ -31,6 +31,15 @@
             </div>
           </div>
           <div class="form-group col-sm-6 col-md-3">
+            <label for="rate">Rate (0 = unlimited)</label>
+            <div class="input-group">
+              <input id="rate" class="form-control" type="number" min="0" max="1000000" step="1" />
+              <div class="input-group-append">
+                <span class="input-group-text">kbit/s</span>
+              </div>
+            </div>
+          </div>
+          <div class="form-group col-sm-6 col-md-3">
             <div class="btn-group">
               <button id="set_netem_button" class="btn btn-primary">
                 <i class="fas fa-sync-alt" aria-hidden="true"></i>

--- a/html5-client/src/js/jittertrap-programs.js
+++ b/html5-client/src/js/jittertrap-programs.js
@@ -31,6 +31,7 @@
       $("#delay").prop('readonly', true);
       $("#jitter").prop('readonly', true);
       $("#loss").prop('readonly', true);
+      $("#rate").prop('readonly', true);
       $("#set_netem_button").prop('disabled', true);
       $("#clear_netem_button").prop('disabled', true);
       $("#netem_status").html("Program Running");
@@ -42,24 +43,26 @@
               $("#delay").val(0);
               $("#jitter").val(0);
               $("#loss").val(0);
+              $("#rate").val(0);
               JT.ws.set_netem();
               runningProgram.stop();
             },
             i * 1000
           );
         } else {
-          this.timeoutHandles[i] = setTimeout((t, d, j, l) => {
-              console.log(Date.now() + " t = " + t + ", d: " + d + ", j: " + j + ", l:" + l);
-              $("#delay").val(d);
-              $("#jitter").val(j);
-              $("#loss").val(l);
+          /* rate is optional for back-compat with programs authored
+           * before rate-limit support; treat missing as 0 (no limit). */
+          const step = runningProgram.impairments[i];
+          const r = step.rate || 0;
+          this.timeoutHandles[i] = setTimeout(() => {
+              console.log(Date.now() + " t = " + i + ", d: " + step.delay + ", j: " + step.jitter + ", l:" + step.loss + ", r:" + r);
+              $("#delay").val(step.delay);
+              $("#jitter").val(step.jitter);
+              $("#loss").val(step.loss);
+              $("#rate").val(r);
               JT.ws.set_netem();
             },
-            i*1000,
-            i,
-            runningProgram.impairments[i].delay,
-            runningProgram.impairments[i].jitter,
-            runningProgram.impairments[i].loss
+            i * 1000
           );
         }
       }
@@ -78,6 +81,7 @@
       $("#delay").prop('readonly', false);
       $("#jitter").prop('readonly', false);
       $("#loss").prop('readonly', false);
+      $("#rate").prop('readonly', false);
       $("#set_netem_button").prop('disabled', false);
       $("#clear_netem_button").prop('disabled', false);
       $("#netem_status").html("Ready");
@@ -90,10 +94,10 @@
       name: "templateProgram",
       traps: [],
       impairments: {
-        0: { delay: 0,  jitter: 0, loss: 0,   trapid: 0},
-        5: { delay: 10, jitter: 2, loss: 0,   trapid: 0},
-        10: { delay: 15, jitter: 2, loss: 0.1, trapid: 0},
-        15: { delay: 0,  jitter: 0, loss: 0,   trapid: 1},
+        0:  { delay: 0,  jitter: 0, loss: 0,   rate: 0,    trapid: 0},
+        5:  { delay: 10, jitter: 2, loss: 0,   rate: 0,    trapid: 0},
+        10: { delay: 15, jitter: 2, loss: 0.1, rate: 1000, trapid: 0},
+        15: { delay: 0,  jitter: 0, loss: 0,   rate: 0,    trapid: 1},
         20: { stop: true },
       }
     },

--- a/html5-client/src/js/jittertrap-programs.js
+++ b/html5-client/src/js/jittertrap-programs.js
@@ -157,11 +157,14 @@
       $("#delay").val("0");
       $("#jitter").val("0");
       $("#loss").val("0");
+      $("#rate").val("0");
     } else {
       $("#delay").val(params.delay);
       $("#jitter").val(params.jitter);
       /* params.loss is a 10th of a percent (integer). convert it to float */
       $("#loss").val(0.1 * params.loss);
+      /* rate is kbit/s; -1 = no rate limit */
+      $("#rate").val(params.rate > 0 ? params.rate : 0);
     }
     if (runningProgram) {
       $("#netem_status").html("Program Running");

--- a/html5-client/src/js/jittertrap-websocket.js
+++ b/html5-client/src/js/jittertrap-websocket.js
@@ -34,6 +34,7 @@
     /* Less frequent message types */
     'pcap_readypcap_statuspcap_configpcap_triggersample_period' +
     'netem_paramsdev_selectiface_list' +
+    '"rate":' +
     /* Video telemetry fields (less common - only video flows) */
     '"video_codec_source":' +
     '"video_bitrate_kbps":' +
@@ -361,7 +362,9 @@
          'delay': parseInt($("#delay").val(), 10),
          'jitter': parseInt($("#jitter").val(), 10),
          /* convert the float to an integer representing 10ths of percent. */
-         'loss': parseInt(Math.round(10 * $("#loss").val()), 10)
+         'loss': parseInt(Math.round(10 * $("#loss").val()), 10),
+         /* rate in kbit/s; 0 = no rate limit */
+         'rate': parseInt($("#rate").val(), 10) || 0
        }
       });
     sock.send(msg);
@@ -372,6 +375,7 @@
     $("#delay").val(0);
     $("#jitter").val(0);
     $("#loss").val(0);
+    $("#rate").val(0);
     set_netem();
     return false;
   };

--- a/messages/include/jt_msg_netem_params.h
+++ b/messages/include/jt_msg_netem_params.h
@@ -13,6 +13,7 @@ struct jt_msg_netem_params
 	int delay;
 	int jitter;
 	int loss;
+	int rate;
 };
 
 #endif

--- a/messages/src/jt_msg_netem_params.c
+++ b/messages/src/jt_msg_netem_params.c
@@ -9,7 +9,7 @@
 
 static const char *jt_netem_params_test_msg =
     "{\"msg\":\"netem_params\", \"p\":{\"iface\":\"em1\", \"delay\":-1, "
-    "\"jitter\":-1, \"loss\":-1}}";
+    "\"jitter\":-1, \"loss\":-1, \"rate\":-1}}";
 
 const char *jt_netem_params_test_msg_get(void)
 {
@@ -31,8 +31,9 @@ int jt_netem_params_printer(void *data, char *out, int len)
 	       "\tInterface:  %s\n"
 	       "\tDelay:      %dms\n"
 	       "\tJitter:  +/-%dms\n"
-	       "\tLoss:       %d",
-	       p->iface, p->delay, p->jitter, p->loss);
+	       "\tLoss:       %d\n"
+	       "\tRate:       %dkbit/s",
+	       p->iface, p->delay, p->jitter, p->loss, p->rate);
 	return 0;
 }
 
@@ -76,6 +77,15 @@ int jt_netem_params_unpacker(json_t *root, void **data)
 	}
 	params->loss = json_integer_value(token);
 
+	/* 'rate' is optional in incoming set_netem messages from older
+	 * clients; default to 0 (no rate limit) when absent. */
+	token = json_object_get(params_token, "rate");
+	if (token && json_is_integer(token)) {
+		params->rate = json_integer_value(token);
+	} else {
+		params->rate = 0;
+	}
+
 	*data = params;
 	return 0;
 
@@ -94,6 +104,7 @@ int jt_netem_params_packer(void *data, char **out)
 	json_object_set_new(p, "delay", json_integer(params->delay));
 	json_object_set_new(p, "jitter", json_integer(params->jitter));
 	json_object_set_new(p, "loss", json_integer(params->loss));
+	json_object_set_new(p, "rate", json_integer(params->rate));
 
 	json_object_set_new(
 	    t, "msg", json_string(jt_messages[JT_MSG_NETEM_PARAMS_V1].key));

--- a/messages/src/jt_msg_set_netem.c
+++ b/messages/src/jt_msg_set_netem.c
@@ -92,6 +92,13 @@ int jt_set_netem_unpacker(json_t *root, void **data)
 	}
 	params->loss = json_integer_value(token);
 
+	/* 'rate' is optional; older clients omit it and the server treats
+	 * the missing field as "no rate limit" (0). */
+	token = json_object_get(params_token, "rate");
+	params->rate = (token && json_is_integer(token))
+	                   ? json_integer_value(token)
+	                   : 0;
+
 	*data = params;
 	json_object_clear(params_token);
 	return 0;

--- a/server/Makefile
+++ b/server/Makefile
@@ -261,6 +261,17 @@ test-iface-recovery: jt-server
 	fi
 	python3 ./test-iface-recovery.py --binary ./jt-server
 
+# Integration test for netem rate-limit (issue #24). Verifies that set_netem
+# applies the kernel rate via TCA_NETEM_RATE and round-trips through the
+# websocket protocol. Same runtime requirements as test-iface-recovery.
+.PHONY: test-rate-limit
+test-rate-limit: jt-server
+	@if ! getcap ./jt-server | grep -q cap_net_admin; then \
+		echo "Grant caps first: sudo setcap 'cap_net_raw,cap_net_admin,cap_sys_nice+ep' ./jt-server"; \
+		exit 1; \
+	fi
+	python3 ./test-rate-limit.py --binary ./jt-server
+
 # Performance benchmark target - builds with optimization and SPEED_TEST
 # Uses high stale threshold (1M) so consumers don't get marked stale during benchmark
 bench-mq-mt: $(MQ_MT_TEST_SOURCES) $(MQ_TEST_HEADERS) $(MQ_HEADERS) $(MQ_DEPENDS)

--- a/server/jt_server_message_handler.c
+++ b/server/jt_server_message_handler.c
@@ -70,7 +70,10 @@ static int set_netem(void *data)
 #else
 	struct jt_msg_netem_params *p1 = data;
 	struct netem_params p2 = {
-		.delay = p1->delay, .jitter = p1->jitter, .loss = p1->loss,
+		.delay = p1->delay,
+		.jitter = p1->jitter,
+		.loss = p1->loss,
+		.rate = p1->rate < 0 ? 0 : (uint32_t)p1->rate,
 	};
 
 	netem_set_params(p1->iface, &p2);
@@ -261,14 +264,16 @@ int jt_srv_send_netem_params(void)
 
 	if (0 != netem_get_params(p.iface, &p)) {
 		/* There need not be a netem qdisc on the interface */
-		p.delay = -1;
-		p.jitter = -1;
-		p.loss = -1;
+		m->delay = -1;
+		m->jitter = -1;
+		m->loss = -1;
+		m->rate = -1;
+	} else {
+		m->delay = p.delay;
+		m->jitter = p.jitter;
+		m->loss = p.loss;
+		m->rate = (int)p.rate;
 	}
-
-	m->delay = p.delay;
-	m->jitter = p.jitter;
-	m->loss = p.loss;
 	snprintf(m->iface, MAX_IFACE_LEN, "%s", p.iface);
 
 	int err = jt_srv_send(JT_MSG_NETEM_PARAMS_V1, m);

--- a/server/netem.c
+++ b/server/netem.c
@@ -210,7 +210,7 @@ static int parse_rate_cb(struct nl_msg *msg, void *arg)
 	struct nlmsghdr *nlh = nlmsg_hdr(msg);
 	struct tcmsg *tcm = nlmsg_data(nlh);
 	struct nlattr *tb[TCA_MAX + 1] = { 0 };
-	struct nlattr *attr;
+	struct nlattr *pos, *nested_head;
 	void *opts;
 	int opts_len;
 	int rem;
@@ -235,13 +235,13 @@ static int parse_rate_cb(struct nl_msg *msg, void *arg)
 	/* TCA_OPTIONS = tc_netem_qopt header followed by nested TCA_NETEM_*
 	 * attributes. The kernel does not wrap the qopt in its own nla
 	 * header; it's raw bytes at the start. */
-	attr = (struct nlattr *)((char *)opts + qopt_aligned);
-	nla_for_each_attr(attr, attr, opts_len - qopt_aligned, rem) {
-		if (nla_type(attr) == TCA_NETEM_RATE &&
-		    nla_len(attr) >= (int)sizeof(struct tc_netem_rate)) {
+	nested_head = (struct nlattr *)((char *)opts + qopt_aligned);
+	nla_for_each_attr(pos, nested_head, opts_len - qopt_aligned, rem) {
+		if (nla_type(pos) == TCA_NETEM_RATE &&
+		    nla_len(pos) >= (int)sizeof(struct tc_netem_rate)) {
 			struct tc_netem_rate r;
 			uint64_t kbps;
-			memcpy(&r, nla_data(attr), sizeof(r));
+			memcpy(&r, nla_data(pos), sizeof(r));
 			kbps = (uint64_t)r.rate * 8ULL / 1000ULL;
 			ctx->rate_kbps = kbps > UINT32_MAX
 			                     ? UINT32_MAX
@@ -378,8 +378,11 @@ int netem_get_params(char *iface, struct netem_params *params)
 	 * happen outside nl_sock_mutex, and a failure (e.g. transient ENOBUFS
 	 * on the dump) shouldn't fail the whole get. */
 	params->rate = 0;
-	if (ifindex >= 0)
-		(void)fetch_netem_rate(ifindex, &params->rate);
+	if (ifindex >= 0 && fetch_netem_rate(ifindex, &params->rate) < 0) {
+		syslog(LOG_WARNING,
+		       "netem rate read failed for %s; reporting rate=0",
+		       iface);
+	}
 	return 0;
 
 cleanup_qdisc:

--- a/server/netem.c
+++ b/server/netem.c
@@ -13,9 +13,12 @@
 #include <syslog.h>
 #include <time.h>
 #include <linux/rtnetlink.h>
+#include <linux/pkt_sched.h>
 #include <netlink/netlink.h>
 #include <netlink/msg.h>
+#include <netlink/attr.h>
 #include <netlink/socket.h>
+#include <netlink/utils.h>
 #include <netlink/cache.h>
 #include <netlink/route/link.h>
 #include <netlink/route/qdisc.h>
@@ -27,6 +30,11 @@
 
 static struct nl_sock *sock;
 static struct nl_cache *link_cache, *qdisc_cache;
+
+static const char NETEM_KIND[] = "netem";
+/* Matches the tc(8) default; the previous libnl-based set path inherited
+ * this same default. */
+#define NETEM_QUEUE_LIMIT 1000
 
 #define QUOTE(str) #str
 #define EXPAND_AND_QUOTE(str) QUOTE(str)
@@ -187,6 +195,115 @@ nl_cache_find(struct nl_cache *cache, struct nl_object *filter)
 
 #endif
 
+/* Parsing callback for fetch_netem_rate. The kernel sends one RTM_NEWQDISC
+ * per (ifindex, qdisc) pair when we issue a dump. We pick the one matching
+ * the requested ifindex with kind=netem and pull TCA_NETEM_RATE out of the
+ * raw TCA_OPTIONS payload. */
+struct rate_query_ctx {
+	int ifindex;
+	uint32_t rate_kbps;
+};
+
+static int parse_rate_cb(struct nl_msg *msg, void *arg)
+{
+	struct rate_query_ctx *ctx = arg;
+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+	struct tcmsg *tcm = nlmsg_data(nlh);
+	struct nlattr *tb[TCA_MAX + 1] = { 0 };
+	struct nlattr *attr;
+	void *opts;
+	int opts_len;
+	int rem;
+	size_t qopt_aligned;
+
+	if (nlmsg_parse(nlh, sizeof(*tcm), tb, TCA_MAX, NULL) < 0)
+		return NL_OK;
+	if (tcm->tcm_ifindex != ctx->ifindex)
+		return NL_OK;
+	if (!tb[TCA_KIND] ||
+	    strcmp(nla_data(tb[TCA_KIND]), NETEM_KIND) != 0)
+		return NL_OK;
+	if (!tb[TCA_OPTIONS])
+		return NL_OK;
+
+	opts = nla_data(tb[TCA_OPTIONS]);
+	opts_len = nla_len(tb[TCA_OPTIONS]);
+	qopt_aligned = NLA_ALIGN(sizeof(struct tc_netem_qopt));
+	if ((size_t)opts_len < qopt_aligned)
+		return NL_OK;
+
+	/* TCA_OPTIONS = tc_netem_qopt header followed by nested TCA_NETEM_*
+	 * attributes. The kernel does not wrap the qopt in its own nla
+	 * header; it's raw bytes at the start. */
+	attr = (struct nlattr *)((char *)opts + qopt_aligned);
+	nla_for_each_attr(attr, attr, opts_len - qopt_aligned, rem) {
+		if (nla_type(attr) == TCA_NETEM_RATE &&
+		    nla_len(attr) >= (int)sizeof(struct tc_netem_rate)) {
+			struct tc_netem_rate r;
+			uint64_t kbps;
+			memcpy(&r, nla_data(attr), sizeof(r));
+			kbps = (uint64_t)r.rate * 8ULL / 1000ULL;
+			ctx->rate_kbps = kbps > UINT32_MAX
+			                     ? UINT32_MAX
+			                     : (uint32_t)kbps;
+		}
+	}
+	return NL_OK;
+}
+
+/* Dump qdiscs over a fresh socket and parse out TCA_NETEM_RATE for ifindex.
+ * Uses its own socket to avoid contending with the long-lived `sock` and
+ * its cache callbacks. On error returns -1 and leaves *rate_kbps unchanged.
+ */
+static int fetch_netem_rate(int ifindex, uint32_t *rate_kbps)
+{
+	struct nl_sock *s;
+	struct nl_msg *msg;
+	struct tcmsg tch;
+	struct rate_query_ctx ctx = { .ifindex = ifindex, .rate_kbps = 0 };
+	int err;
+
+	s = nl_socket_alloc();
+	if (!s)
+		return -1;
+	if (nl_connect(s, NETLINK_ROUTE) < 0)
+		goto fail_sock;
+
+	nl_socket_modify_cb(s, NL_CB_VALID, NL_CB_CUSTOM, parse_rate_cb, &ctx);
+
+	msg = nlmsg_alloc();
+	if (!msg)
+		goto fail_sock;
+	memset(&tch, 0, sizeof(tch));
+	tch.tcm_family = AF_UNSPEC;
+	tch.tcm_ifindex = ifindex;
+	if (!nlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, RTM_GETQDISC, 0,
+	               NLM_F_REQUEST | NLM_F_DUMP)) {
+		nlmsg_free(msg);
+		goto fail_sock;
+	}
+	if (nlmsg_append(msg, &tch, sizeof(tch), NLMSG_ALIGNTO) < 0) {
+		nlmsg_free(msg);
+		goto fail_sock;
+	}
+
+	err = nl_send_auto(s, msg);
+	nlmsg_free(msg);
+	if (err < 0)
+		goto fail_sock;
+
+	/* Drain the dump until NLMSG_DONE (libnl returns 0). */
+	while ((err = nl_recvmsgs_default(s)) > 0) { }
+
+	nl_socket_free(s);
+	*rate_kbps = ctx.rate_kbps;
+	return 0;
+
+fail_sock:
+	nl_socket_free(s);
+	return -1;
+}
+
 int netem_get_params(char *iface, struct netem_params *params)
 {
 	struct rtnl_link *link;
@@ -194,6 +311,7 @@ int netem_get_params(char *iface, struct netem_params *params)
 	struct rtnl_qdisc *found_qdisc = NULL;
 	int err;
 	int delay, jitter, loss;
+	int ifindex = -1;
 
 	pthread_mutex_lock(&nl_sock_mutex);
 	if ((err = nl_cache_refill(sock, link_cache)) < 0) {
@@ -213,6 +331,7 @@ int netem_get_params(char *iface, struct netem_params *params)
 		syslog(LOG_ERR, "unknown interface/link name: %s\n", iface);
 		goto cleanup;
 	}
+	ifindex = rtnl_link_get_ifindex(link);
 
 	if (!(filter_qdisc = rtnl_qdisc_alloc())) {
 		/* OOM error */
@@ -254,6 +373,13 @@ int netem_get_params(char *iface, struct netem_params *params)
 	rtnl_qdisc_put(filter_qdisc);
 	rtnl_link_put(link);
 	pthread_mutex_unlock(&nl_sock_mutex);
+
+	/* Rate read is best-effort: it uses an auxiliary socket so it must
+	 * happen outside nl_sock_mutex, and a failure (e.g. transient ENOBUFS
+	 * on the dump) shouldn't fail the whole get. */
+	params->rate = 0;
+	if (ifindex >= 0)
+		(void)fetch_netem_rate(ifindex, &params->rate);
 	return 0;
 
 cleanup_qdisc:
@@ -267,50 +393,96 @@ cleanup:
 	return -1;
 }
 
+/* libnl-route 3.x does not expose rtnl_netem_set_rate, so the qdisc message is
+ * built manually here. The wire format inside TCA_OPTIONS is:
+ *   - struct tc_netem_qopt (raw bytes, no nla header)
+ *   - followed by optional nested attributes (TCA_NETEM_RATE, ...)
+ * This is the layout that the kernel netem_change() expects and matches what
+ * the tc(8) utility produces. */
 int netem_set_params(const char *iface, struct netem_params *params)
 {
 	struct rtnl_link *link;
-	struct rtnl_qdisc *qdisc;
+	struct nl_msg *msg = NULL;
+	struct nlattr *opts;
+	struct tcmsg tch;
+	struct tc_netem_qopt qopt;
+	int ifindex;
 	int err;
 
 	pthread_mutex_lock(&nl_sock_mutex);
 
-	/* filter link by name */
 	if ((link = rtnl_link_get_by_name(link_cache, iface)) == NULL) {
 		syslog(LOG_ERR, "unknown interface/link name.\n");
 		pthread_mutex_unlock(&nl_sock_mutex);
 		return -1;
 	}
+	ifindex = rtnl_link_get_ifindex(link);
+	rtnl_link_put(link);
 
-	if (!(qdisc = rtnl_qdisc_alloc())) {
-		/* OOM error */
-		syslog(LOG_ERR, "couldn't alloc qdisc\n");
+	msg = nlmsg_alloc();
+	if (!msg) {
+		syslog(LOG_ERR, "couldn't alloc nl_msg\n");
 		pthread_mutex_unlock(&nl_sock_mutex);
 		return -1;
 	}
 
-	rtnl_tc_set_link(TC_CAST(qdisc), link);
-	rtnl_tc_set_parent(TC_CAST(qdisc), TC_H_ROOT);
-	rtnl_tc_set_kind(TC_CAST(qdisc), "netem");
+	memset(&tch, 0, sizeof(tch));
+	tch.tcm_family = AF_UNSPEC;
+	tch.tcm_ifindex = ifindex;
+	tch.tcm_parent = TC_H_ROOT;
 
-	rtnl_netem_set_delay(qdisc,
-	                     params->delay * 1000); /* expects microseconds */
-	rtnl_netem_set_jitter(qdisc, params->jitter * 1000);
-	/* params->loss is given in 10ths of a percent */
-	rtnl_netem_set_loss(qdisc, (params->loss * (UINT_MAX / 1000)));
+	/* Pass 0 for payload size so nlmsg_put doesn't reserve any bytes
+	 * before the appended family header — the kernel reads tcmsg at
+	 * NLMSG_DATA, so the appended bytes must be flush against the
+	 * nlmsghdr. */
+	if (!nlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, RTM_NEWQDISC, 0,
+	               NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE |
+	                   NLM_F_REPLACE)) {
+		goto fail_msg;
+	}
+	if (nlmsg_append(msg, &tch, sizeof(tch), NLMSG_ALIGNTO) < 0)
+		goto fail_msg;
 
-	/* Submit request to kernel and wait for response */
-	err = rtnl_qdisc_add(sock, qdisc, NLM_F_CREATE | NLM_F_REPLACE);
+	if (nla_put_string(msg, TCA_KIND, NETEM_KIND) < 0)
+		goto fail_msg;
 
-	/* Return the qdisc object to free memory resources */
-	rtnl_qdisc_put(qdisc);
+	opts = nla_nest_start(msg, TCA_OPTIONS);
+	if (!opts)
+		goto fail_msg;
+
+	memset(&qopt, 0, sizeof(qopt));
+	/* latency and jitter are in PSCHED ticks, not microseconds. */
+	qopt.latency = nl_us2ticks(params->delay * 1000);
+	qopt.jitter = nl_us2ticks(params->jitter * 1000);
+	qopt.loss = params->loss * (UINT_MAX / 1000);
+	qopt.limit = NETEM_QUEUE_LIMIT;
+	if (nlmsg_append(msg, &qopt, sizeof(qopt), NLMSG_ALIGNTO) < 0)
+		goto fail_msg;
+
+	{
+		/* TCA_NETEM_RATE is always emitted, even when rate==0, so that
+		 * a previously-set rate is explicitly cleared. The kernel only
+		 * updates q->rate from attributes that are present. */
+		struct tc_netem_rate r;
+		uint64_t bytes_per_sec = (uint64_t)params->rate * 1000ULL / 8ULL;
+
+		memset(&r, 0, sizeof(r));
+		/* TCA_NETEM_RATE.rate is u32 byte/s; cap at UINT32_MAX. The
+		 * RATE64 attribute exists for >4Gbit/s use cases but is not
+		 * exposed in the UI. */
+		r.rate = bytes_per_sec > UINT32_MAX ? UINT32_MAX
+		                                    : (uint32_t)bytes_per_sec;
+		if (nla_put(msg, TCA_NETEM_RATE, sizeof(r), &r) < 0)
+			goto fail_msg;
+	}
+
+	nla_nest_end(msg, opts);
+
+	err = nl_send_sync(sock, msg);
+	msg = NULL; /* nl_send_sync frees on both success and failure */
 
 	if (err < 0) {
-		/*
-		 * NLE_PERM (-10) or -EPERM (-1) indicates permission denied.
-		 * This happens when running without CAP_NET_ADMIN.
-		 */
-		if (err == -EPERM || err == -10) {
+		if (err == -NLE_PERM) {
 			syslog(LOG_WARNING,
 			       "Unable to add qdisc: permission denied. "
 			       "Network impairment features require CAP_NET_ADMIN.");
@@ -331,6 +503,11 @@ int netem_set_params(const char *iface, struct netem_params *params)
 
 	pthread_mutex_unlock(&nl_sock_mutex);
 	return 0;
+
+fail_msg:
+	nlmsg_free(msg);
+	pthread_mutex_unlock(&nl_sock_mutex);
+	return -1;
 }
 
 /* ---- netlink link-change monitor ---------------------------------------- */

--- a/server/netem.h
+++ b/server/netem.h
@@ -5,6 +5,7 @@ struct netem_params {
 	uint32_t delay;  /* milliseconds */
 	uint32_t jitter; /* milliseconds */
 	uint32_t loss;   /* percentage, [0-100] */
+	uint32_t rate;   /* kilobits per second; 0 = no rate limit */
 	char iface[MAX_IFACE_LEN];
 };
 

--- a/server/test-rate-limit.py
+++ b/server/test-rate-limit.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Integration test for netem rate-limit support (issue #24).
+
+Exercises the new 'rate' parameter end-to-end:
+
+  - set_netem with rate=N kbit/s applies the qdisc; tc shows the rate.
+  - The server's netem_params reply carries rate=N.
+  - clear_netem (rate=0, all params 0) restores no-rate state.
+  - Old clients sending set_netem without 'rate' don't break the server.
+
+Requires:
+  - jt-server with CAP_NET_ADMIN (setcap)
+  - passwordless sudo for `ip link` and `tc`
+  - python3 with the websockets module
+
+Exit code is 0 on success, non-zero on any failure.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from contextlib import asynccontextmanager
+
+try:
+    import websockets
+except ImportError:
+    print("Error: websockets module not found. Install with: pip install websockets")
+    sys.exit(2)
+
+
+def sh(cmd, check=False):
+    r = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise RuntimeError(f"{cmd!r} failed: {r.stderr}")
+    return r
+
+
+def ensure_iface(name):
+    sh(f"sudo -n ip link del {name} 2>/dev/null")
+    sh(f"sudo -n ip link add {name} type dummy", check=True)
+    sh(f"sudo -n ip link set {name} up", check=True)
+
+
+def remove_iface(name):
+    sh(f"sudo -n ip link del {name} 2>/dev/null")
+
+
+def tc_rate_bps(iface):
+    """Return the netem qdisc 'rate' on iface as bytes/s, or 0 if none."""
+    r = sh(f"sudo -n tc qdisc show dev {iface}")
+    if r.returncode != 0:
+        return 0
+    # tc output examples:
+    #  "qdisc netem 8001: root refcnt 2 limit 1000 rate 125Kbit"
+    #  "qdisc netem 8001: root refcnt 2 limit 1000 rate 1Mbit"
+    m = re.search(r"\brate\s+(\d+)([KMG]?)bit\b", r.stdout)
+    if not m:
+        return 0
+    n = int(m.group(1))
+    mult = {"": 1, "K": 1000, "M": 1_000_000, "G": 1_000_000_000}[m.group(2)]
+    return n * mult // 8  # bit/s -> byte/s
+
+
+@asynccontextmanager
+async def server(port, allowed, binary):
+    log_path = f"/tmp/jts-rate-limit-{os.getpid()}.log"
+    if os.path.exists(log_path):
+        os.unlink(log_path)
+    env = os.environ.copy()
+    env.setdefault("ASAN_OPTIONS", "detect_leaks=1:halt_on_error=0:exitcode=23")
+    proc = subprocess.Popen(
+        [binary, "-p", str(port), "-a", allowed],
+        stdout=open(log_path, "w"),
+        stderr=subprocess.STDOUT,
+        env=env,
+        preexec_fn=os.setpgrp,
+    )
+    try:
+        for _ in range(50):
+            if proc.poll() is not None:
+                with open(log_path) as f:
+                    sys.stderr.write(f.read())
+                raise RuntimeError("server exited during startup")
+            r = sh(f"ss -ltn 'sport = :{port}' 2>/dev/null | grep -q :{port}")
+            if r.returncode == 0:
+                break
+            await asyncio.sleep(0.05)
+        else:
+            raise RuntimeError(f"server not listening on {port} after 2.5s")
+        yield log_path, proc
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+            proc.wait(timeout=3)
+        except Exception:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except Exception:
+                pass
+
+
+class Client:
+    """Tracks netem_params and dev_select messages."""
+
+    def __init__(self, ws):
+        self.ws = ws
+        self.events: list[tuple[float, str, dict]] = []
+        self._stop = asyncio.Event()
+        self._task: asyncio.Task | None = None
+
+    async def _drain(self):
+        try:
+            while not self._stop.is_set():
+                try:
+                    raw = await asyncio.wait_for(self.ws.recv(), timeout=0.2)
+                except asyncio.TimeoutError:
+                    continue
+                # netem_params is a short message (<128 bytes) so it
+                # arrives uncompressed as text/utf-8 JSON.
+                if isinstance(raw, bytes):
+                    # could be a compressed frame; skip — we don't need it
+                    continue
+                try:
+                    msg = json.loads(raw)
+                except Exception:
+                    continue
+                if msg.get("msg") in ("netem_params", "dev_select", "iface_list"):
+                    self.events.append((time.monotonic(), msg["msg"], msg.get("p")))
+        except websockets.ConnectionClosed:
+            pass
+
+    def start(self):
+        self._task = asyncio.create_task(self._drain())
+
+    async def stop(self):
+        self._stop.set()
+        if self._task:
+            await self._task
+
+    async def send(self, msg):
+        await self.ws.send(json.dumps(msg))
+
+    def last_netem(self):
+        for ts, kind, p in reversed(self.events):
+            if kind == "netem_params":
+                return p
+        return None
+
+    async def wait_netem_with(self, predicate, timeout=2.0):
+        """Wait until a netem_params event satisfying predicate arrives, or timeout."""
+        deadline = time.monotonic() + timeout
+        seen = len(self.events)
+        while time.monotonic() < deadline:
+            for ts, kind, p in self.events[seen:]:
+                if kind == "netem_params" and predicate(p):
+                    return p
+            seen = len(self.events)
+            await asyncio.sleep(0.05)
+        return None
+
+
+@asynccontextmanager
+async def connect(port):
+    uri = f"ws://localhost:{port}/"
+    async with websockets.connect(uri, subprotocols=["jittertrap"], compression=None) as ws:
+        c = Client(ws)
+        c.start()
+        await asyncio.sleep(0.6)  # let initial messages flow
+        try:
+            yield c
+        finally:
+            await c.stop()
+
+
+# ----------------------------------------------------------------------------
+# tests
+
+async def test_set_and_verify_rate(port, iface):
+    """set_netem with rate=1000 kbit/s applies qdisc; server reports same rate."""
+    async with connect(port) as c:
+        await c.send({"msg": "dev_select", "p": {"iface": iface}})
+        await asyncio.sleep(0.4)
+
+        # Set delay=10ms loss=0 rate=1000kbit
+        await c.send({
+            "msg": "set_netem",
+            "p": {"dev": iface, "delay": 10, "jitter": 0, "loss": 0, "rate": 1000}
+        })
+        got = await c.wait_netem_with(lambda p: p.get("rate", 0) > 0, timeout=2.0)
+        assert got is not None, "server never echoed netem_params with rate>0"
+        assert got.get("rate") == 1000, f"server reported rate={got.get('rate')}, expected 1000"
+        assert got.get("delay") == 10, f"delay round-trip lost: {got}"
+
+        # Cross-check with tc directly
+        bps = tc_rate_bps(iface)
+        # 1000 kbit/s = 125000 byte/s
+        assert abs(bps - 125000) < 250, \
+            f"tc qdisc shows rate={bps} byte/s, expected ~125000"
+    return f"set rate=1000kbit verified via tc and netem_params"
+
+
+async def test_clear_rate(port, iface):
+    """Setting rate=0 with non-zero delay leaves netem active but unrate-limited."""
+    async with connect(port) as c:
+        await c.send({"msg": "dev_select", "p": {"iface": iface}})
+        await asyncio.sleep(0.4)
+
+        await c.send({
+            "msg": "set_netem",
+            "p": {"dev": iface, "delay": 5, "jitter": 0, "loss": 0, "rate": 500}
+        })
+        await c.wait_netem_with(lambda p: p.get("rate") == 500, timeout=2.0)
+
+        # Now reset rate to 0
+        await c.send({
+            "msg": "set_netem",
+            "p": {"dev": iface, "delay": 5, "jitter": 0, "loss": 0, "rate": 0}
+        })
+        got = await c.wait_netem_with(lambda p: p.get("rate", -2) == 0, timeout=2.0)
+        assert got is not None, "server never echoed netem_params with rate=0"
+
+        bps = tc_rate_bps(iface)
+        assert bps == 0, f"tc qdisc still reports rate={bps} after clear"
+    return "rate cleared via set_netem rate=0"
+
+
+async def test_old_client_compat(port, iface):
+    """A client that omits 'rate' in set_netem must not crash the server.
+
+    The server-side unpacker treats missing 'rate' as 0 (no rate limit)."""
+    async with connect(port) as c:
+        await c.send({"msg": "dev_select", "p": {"iface": iface}})
+        await asyncio.sleep(0.4)
+
+        # First set a rate, then issue an old-style set_netem without 'rate'
+        await c.send({
+            "msg": "set_netem",
+            "p": {"dev": iface, "delay": 5, "jitter": 0, "loss": 0, "rate": 750}
+        })
+        await c.wait_netem_with(lambda p: p.get("rate") == 750, timeout=2.0)
+
+        # Old-format message: no 'rate' key
+        await c.send({
+            "msg": "set_netem",
+            "p": {"dev": iface, "delay": 8, "jitter": 0, "loss": 0}
+        })
+        got = await c.wait_netem_with(lambda p: p.get("delay") == 8, timeout=2.0)
+        assert got is not None, "server didn't reply to old-style set_netem"
+        # Old-style set replaces the qdisc fresh; the missing rate should mean
+        # no rate limit (0).
+        assert got.get("rate", 0) == 0, \
+            f"old-style set_netem unexpectedly kept rate={got.get('rate')}"
+    return "old client (no 'rate' field) accepted by server"
+
+
+# ----------------------------------------------------------------------------
+async def run_all(args):
+    iface = "jt-rate-test"
+    ensure_iface(iface)
+    try:
+        async with server(args.port, f"lo:{iface}", args.binary) as (log_path, proc):
+            results = []
+            try:
+                results.append(await test_set_and_verify_rate(args.port, iface))
+                results.append(await test_clear_rate(args.port, iface))
+                results.append(await test_old_client_compat(args.port, iface))
+            except AssertionError as e:
+                print(f"FAIL: {e}")
+                for r in results:
+                    print(f"  ok: {r}")
+                print("---- last 60 lines of server log ----")
+                with open(log_path) as f:
+                    lines = f.readlines()
+                sys.stdout.write("".join(lines[-60:]))
+                return 1
+            except Exception as e:
+                print(f"ERROR: {e}")
+                return 2
+
+            with open(log_path) as f:
+                log_text = f.read()
+            for marker in ("ERROR: AddressSanitizer", "==ERROR==", "SUMMARY: AddressSanitizer"):
+                if marker in log_text:
+                    print(f"FAIL: server log contains {marker!r}")
+                    for r in results:
+                        print(f"  ok: {r}")
+                    idx = log_text.find(marker)
+                    print(log_text[max(0, idx - 200):idx + 2000])
+                    return 1
+
+            for r in results:
+                print(f"ok: {r}")
+            print("All rate-limit integration tests passed.")
+            return 0
+    finally:
+        remove_iface(iface)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", default="./jt-server",
+                        help="path to jt-server (default ./jt-server)")
+    parser.add_argument("--port", type=int, default=8766)
+    args = parser.parse_args()
+    return asyncio.run(run_all(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/ws_compress.c
+++ b/server/ws_compress.c
@@ -34,6 +34,7 @@ static const char ws_dictionary[] =
 	/* Less frequent message types */
 	"pcap_readypcap_statuspcap_configpcap_triggersample_period"
 	"netem_paramsdev_selectiface_list"
+	"\"rate\":"
 	/* Video telemetry fields (less common - only video flows) */
 	"\"video_codec_source\":"
 	"\"video_bitrate_kbps\":"


### PR DESCRIPTION
## Summary

Closes #24. Adds the `rate` parameter of the netem qdisc end-to-end:

- **UI**: new \"Rate (0 = unlimited)\" input on the Impairments panel, in the existing row with delay/jitter/loss.
- **Wire protocol**: `set_netem` gains an optional `rate` field (kbit/s); `netem_params` reports current rate in kbit/s (-1 when no netem qdisc is set, matching how delay/loss/jitter signal \"no qdisc\").
- **Server**: builds the qdisc message manually using libnl's `nl_msg` helpers because libnl-route 3.x doesn't expose `rtnl_netem_set_rate`. Sets the `TCA_NETEM_RATE` attribute every time — necessary so that clearing a previously-applied rate actually clears it (the kernel only updates fields present in the attribute set).
- **Read-back** uses an auxiliary `RTM_GETQDISC` dump on a separate socket; the cached qdisc objects libnl maintains drop the raw nested attributes, so we re-fetch and parse `TCA_OPTIONS` manually. This is best-effort and runs outside `nl_sock_mutex`.

Issue task (1) said \"Add support for the 'rate' parameter of the netem qdisc to libnl\" and (2) \"Work with upstream to merge this.\" — both deferred. The kernel ABI is stable enough that doing this in-tree (no libnl patch required) was cleaner than carrying a libnl fork.

## Test plan

Automated (`make test-rate-limit` — runs under AddressSanitizer):

- [x] `test_set_and_verify_rate`: server applies rate=1000 kbit/s; netem_params echoes rate=1000; `tc qdisc show` reports `rate 1Mbit`.
- [x] `test_clear_rate`: set rate=500, then rate=0; tc reports no rate line; netem_params reports rate=0.
- [x] `test_old_client_compat`: a `set_netem` from a client that omits the `rate` field is accepted; the server treats missing rate as 0.
- [x] Existing `test-iface-recovery` integration tests pass (regression check).
- [x] `messages/test-packing` self-test for netem_params/set_netem round-trip passes with the new field.

Manual:

- [ ] Browser smoke test (manual): connect, set rate, verify UI input round-trips on refresh; verify clearing.

## Notes / not-fixed

- `TCA_NETEM_RATE64` (rates > 4 Gbit/s) is not parsed on read-back. UI caps at 1 Gbit/s, well below the u32 byte/s ceiling, so this matters only for hypothetical multi-Gbit/s setups via direct WS messages.
- A short-lived netlink socket is opened per rate-read. Call rate is user-driven (≤ a few/sec), so socket churn is acceptable; could be pooled later if it shows up in profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)